### PR TITLE
챌린지 키워드에 "전체" 항목 추가

### DIFF
--- a/src/api/challenges/challenges.service.ts
+++ b/src/api/challenges/challenges.service.ts
@@ -50,6 +50,10 @@ export class ChallengesService {
   }
 
   async getChallengeTitles(): Promise<GetChallengeTitleDTO[]> {
-    return await this.challengesRepository.getChallengeTitles();
+    const challengeTitles =
+      await this.challengesRepository.getChallengeTitles();
+    challengeTitles.unshift({id: 0, title: '전체'});
+
+    return challengeTitles;
   }
 }


### PR DESCRIPTION
챌린지 필터를 통해 피드 목록을 조회할때, 0(전체)으로 선택한 경우 전체 검색이 가능하도록 수정
```
{
  "id" : 0,
  "title": "전체
}
```