### PR TITLE
피드 게시글 API 로직 수정

### DIFF
--- a/src/api/feed/dto/feed.dto.ts
+++ b/src/api/feed/dto/feed.dto.ts
@@ -129,7 +129,7 @@ export class GetFeedImageResDTO {
 
   @ApiProperty({
     description: '피드 이미지 url',
-    example: '[{aws.s3.endpoint}/feed/filename.png]',
+    example: '{aws.s3.endpoint}/feed/filename.png',
   })
   private fileUrl: string;
 
@@ -151,6 +151,12 @@ export class GetFeedResDTO {
     example: 'https://github.com/hiong04',
   })
   private userImage: string;
+
+  @ApiProperty({
+    description: '게시글 내용',
+    example: '패키지 상품을 받았을때의 기쁨 후엔 늘 골치아픈 쓰레기와 분리수거',
+  })
+  private content: string;
 
   @ApiProperty({description: '작성 시간(생성일)', example: '1시간전'})
   private regDateToString: string;
@@ -178,6 +184,7 @@ export class GetFeedResDTO {
     id: number,
     userName: string,
     userImage: string,
+    content: string,
     regDateToString: string,
     scale: string,
     blogLikeCount: string,
@@ -188,6 +195,7 @@ export class GetFeedResDTO {
     this.id = id;
     this.userName = userName;
     this.userImage = userImage;
+    this.content = content;
     this.regDateToString = regDateToString;
     this.scale = scale;
     this.blogLikeCount = blogLikeCount;

--- a/src/api/feed/repository/blogChallenges.repository.ts
+++ b/src/api/feed/repository/blogChallenges.repository.ts
@@ -2,7 +2,7 @@ import {Injectable} from '@nestjs/common';
 import {EntityRepository, getManager, QueryRunner, Repository} from 'typeorm';
 import {CreateBlogChallengesDTO, GetBlogChallengesDTO} from '../dto/feed.dto';
 import {BlogChallenges} from 'src/entities/BlogChallenges';
-import { Challenges } from 'src/entities/Challenges';
+import {Challenges} from 'src/entities/Challenges';
 
 @Injectable()
 @EntityRepository(BlogChallenges)
@@ -32,16 +32,16 @@ export class BlogChallengesRepository extends Repository<BlogChallenges> {
       .getMany();
   }
 
-  async getBlogChallengesByPostId(id: number){
-    const challenges:GetBlogChallengesDTO[] = await getManager()
-    .createQueryBuilder()
-    .select('bc.id', 'id')
-    .addSelect('bc.challenge_id', 'challengeId')
-    .addSelect('c.title', 'title')
-    .from(BlogChallenges, 'bc')
-    .innerJoin(Challenges, 'c', 'bc.challenge_id = c.id')
-    .where("bc.post_id = :id", { id: id })
-    .getRawMany();
+  async getBlogChallengesByPostId(id: number) {
+    const challenges: GetBlogChallengesDTO[] = await getManager()
+      .createQueryBuilder()
+      .select('bc.id', 'id')
+      .addSelect('bc.challenge_id', 'challengeId')
+      .addSelect('c.title', 'title')
+      .from(BlogChallenges, 'bc')
+      .innerJoin(Challenges, 'c', 'bc.challenge_id = c.id')
+      .where('bc.post_id = :id', {id: id})
+      .getRawMany();
 
     return challenges;
   }

--- a/src/api/feed/repository/blogPost.repository.ts
+++ b/src/api/feed/repository/blogPost.repository.ts
@@ -61,14 +61,15 @@ export class BlogPostRepository
     page: number,
     take: number,
     blogPostIds: number[],
-    excludeBlogPostId: number,
+    excludeBlogPostId?: number,
   ): Promise<IGetBlogPostItems> {
-    let queryBuilder = await this.createQueryBuilder('blogPost').where(
-      'blogPost.id != :id',
-      {
+    let queryBuilder = await this.createQueryBuilder('blogPost');
+
+    if (excludeBlogPostId) {
+      queryBuilder = queryBuilder.where('blogPost.id != :id', {
         id: excludeBlogPostId,
-      },
-    );
+      });
+    }
 
     if (blogPostIds.length > 0) {
       queryBuilder = queryBuilder.andWhereInIds(blogPostIds);


### PR DESCRIPTION
- content 필드 추가
- swagger example 수정
- 피드 게시글의 페이지네이션 로직 수정
  - 현재 페이지가 1일 경우 로직 수정
  - 요청 페이지가 1이하인 경우 발생하는 문제 유지(현재 엣지 케이스)