### PR TITLE
hotfix: 댓글조회 리턴값 타입 변경

### DIFF
--- a/src/api/feed/dto/feed.dto.ts
+++ b/src/api/feed/dto/feed.dto.ts
@@ -442,6 +442,7 @@ export class GetBlogCommentDTO {
     description: '삭제 여부',
     example: 'false',
   })
+  @Transform(({ value }) => value === "true" || value === true || value === 1)
   isDeleted: boolean;
 }
 


### PR DESCRIPTION
- #99 
as is : 해당 컬럼이 tinyint로 되어있어 0,1로 되어있는 데이터를 그대로 전송
to be: class-validator를 이용하여 boolean타입으로 변경

다예님이 요청해주신 간단한 수정입니다~!