### PR TITLE
feature: 댓글삭제 개발

### DIFF
--- a/src/api/feed/dto/feed.dto.ts
+++ b/src/api/feed/dto/feed.dto.ts
@@ -392,6 +392,16 @@ export class InsBlogCommentDTO extends OmitType(BlogComment, [
   'isDeleted',
 ]) {}
 
+export class DelBlogCommentReqDTO {
+  @IsNotEmpty()
+  @ApiProperty({description: '댓글 id', example: '1'})
+  id: number;
+
+  // @IsNotEmpty()
+  // @ApiProperty({description: '게시글 id', example: '1'})
+  // post_id: number;
+}
+
 @Exclude()
 export class GetBlogCommentDTO {
   @Expose()

--- a/src/api/feed/feed.controller.ts
+++ b/src/api/feed/feed.controller.ts
@@ -23,6 +23,7 @@ import {
   GetFeedViewResDTO,
   GetListFeedCommentReqDTO,
   GetListFeedCommentResDTO,
+  DelBlogCommentReqDTO,
 } from './dto/feed.dto';
 import {
   ApiCreatedResponse,
@@ -34,7 +35,8 @@ import {FilesInterceptor} from '@nestjs/platform-express';
 import {
   FeedCreateResponse,
   GetFeedViewResponse,
-  GetFeedCommentResponse
+  GetFeedCommentResponse,
+  DeleteBlogCommentResponse,
 } from 'src/shared/response_entities/feed/temp.response';
 
 // TODO: 400,401,403,404등 공통 사용 응답코드는 컨트롤러에 붙이기
@@ -167,7 +169,7 @@ export class FeedController {
 
   @Get(':id/comment')
   @ApiOperation({summary: '댓글 목록 조회'})
-  @ApiCreatedResponse({
+  @ApiResponse({
     description: '성공',
     type: GetFeedCommentResponse,
   })
@@ -177,13 +179,40 @@ export class FeedController {
       message: 'success',
       data: null,
     };
-    
-    try{
-      const comments:GetListFeedCommentResDTO[] = await this.feedService.getListFeedComment(param);
+
+    try {
+      const comments: GetListFeedCommentResDTO[] =
+        await this.feedService.getListFeedComment(param);
       result.data = comments;
     } catch (e) {
       result.code = 500;
       result.message = e.message;
+    }
+
+    return result;
+  }
+
+  @Delete('/comment')
+  @ApiOperation({summary: '댓글 삭제'})
+  @ApiResponse({
+    description: '성공',
+    type: DeleteBlogCommentResponse,
+  })
+  async deleteBlogComment(@Body() delBlogCommentReqDTO: DelBlogCommentReqDTO) {
+    const result: DeleteBlogCommentResponse = {
+      code: 200,
+      message: 'success',
+      data: {
+        status: true,
+      },
+    };
+
+    try {
+      await this.feedService.deleteBlogComment(delBlogCommentReqDTO);
+    } catch (e) {
+      result.code = 500;
+      result.message = e.message;
+      result.data.status = false;
     }
 
     return result;

--- a/src/api/feed/feed.service.ts
+++ b/src/api/feed/feed.service.ts
@@ -22,6 +22,7 @@ import {
   GetListFeedCommentReqDTO,
   GetListFeedCommentResDTO,
   GetBlogCommentDTO,
+  DelBlogCommentReqDTO,
 } from './dto/feed.dto';
 import {ImageService} from 'src/api/image/image.service';
 import {BlogChallengesRepository} from './repository/blogChallenges.repository';
@@ -36,6 +37,7 @@ import {
 } from './interface/blogPost.interface';
 import {convertTimeToStr, isPageNext} from '../../shared/utils';
 import {BlogPost} from '@entities/BlogPost';
+import { BlogComment } from '@entities/BlogComment';
 
 @Injectable()
 export class FeedService {
@@ -365,6 +367,17 @@ export class FeedService {
     } catch (e) {
       this.logger.error(e);
       throw new Error(e);
+    }
+  }
+
+  async deleteBlogComment({id}: DelBlogCommentReqDTO) {
+    try {
+      const comment: BlogComment = await this.blogCommentRepository.getBlogComment(id);
+      comment.isDeleted = true;
+      comment.delDate = new Date();
+      await this.blogCommentRepository.saveBlogComment(null, comment);
+    } catch (e) {
+      throw new Error(e.message);
     }
   }
 }

--- a/src/api/feed/repository/blogComment.repository.ts
+++ b/src/api/feed/repository/blogComment.repository.ts
@@ -7,15 +7,14 @@ import { User } from 'src/entities/User';
 @Injectable()
 @EntityRepository(BlogComment)
 export class BlogCommentRepository extends Repository<BlogComment> {
-  createBlogComment(insBlogCommentDTO: InsBlogCommentDTO): BlogComment {
-    return this.create({...insBlogCommentDTO});
-  }
-
-  async saveBlogComment(queryRunner: QueryRunner | null, BlogComment: BlogComment): Promise<BlogComment> {
-    if(queryRunner === null){
-        return await this.save(BlogComment);
+  async saveBlogComment(
+    queryRunner: QueryRunner | null,
+    BlogComment: BlogComment,
+  ): Promise<BlogComment> {
+    if (queryRunner === null) {
+      return await this.save(BlogComment);
     } else {
-        return await queryRunner.manager.save(BlogComment);
+      return await queryRunner.manager.save(BlogComment);
     }
   }
 
@@ -26,7 +25,7 @@ export class BlogCommentRepository extends Repository<BlogComment> {
    * @param id postId
    * @returns GetFeedCommentResDTO
    */
-  async getBlogCommentByPostId(id: number){
+  async getBlogCommentByPostId(id: number) {
     const cntQb = getManager()
       .createQueryBuilder()
       .select('comment_id', 'reply_id')
@@ -35,22 +34,29 @@ export class BlogCommentRepository extends Repository<BlogComment> {
       .where('b.comment_id IS NOT NULL')
       .groupBy('b.comment_id');
 
-    const comment:GetListFeedCommentResDTO[] = await getManager()
+    const comment: GetListFeedCommentResDTO[] = await getManager()
       .createQueryBuilder()
       .select('bc.id', 'id')
       .addSelect('bc.user_id', 'userId')
       .addSelect('u.nickname', 'nickname')
       .addSelect('u.image', 'image')
       .addSelect('bc.is_deleted', 'isDeleted')
-      .addSelect('IF( bc.is_deleted = 1, "삭제된 댓글입니다.", bc.content )', 'content')
+      .addSelect(
+        'IF( bc.is_deleted = 1, "삭제된 댓글입니다.", bc.content )',
+        'content',
+      )
       .addSelect('bc.reg_date', 'regDate')
       .addSelect('IFNULL(bcnt.cnt, 0)', 'replyCnt')
       .from(BlogComment, 'bc')
       .innerJoin(User, 'u', 'bc.user_id = u.id')
-      .leftJoinAndSelect('(' + cntQb.getQuery() + ')', 'bcnt', 'bc.id = bcnt.reply_id')
+      .leftJoinAndSelect(
+        '(' + cntQb.getQuery() + ')',
+        'bcnt',
+        'bc.id = bcnt.reply_id',
+      )
       .where('(bcnt.cnt != 0 OR is_deleted = 0)')
       .andWhere('bc.comment_id IS NULL')
-      .andWhere('bc.post_id = :id', { id: id })
+      .andWhere('bc.post_id = :id', {id: id})
       .orderBy('bc.id', 'ASC')
       .getRawMany();
 
@@ -62,7 +68,7 @@ export class BlogCommentRepository extends Repository<BlogComment> {
    * @param id 부모 댓글 id
    * @returns GetBlogCommentDTO
    */
-  async getBlogCommentByCommentId(id: number){
+  async getBlogCommentByCommentId(id: number) {
     const comment: GetBlogCommentDTO[] = await getManager()
       .createQueryBuilder()
       .select('bc.id', 'id')
@@ -75,10 +81,14 @@ export class BlogCommentRepository extends Repository<BlogComment> {
       .from(BlogComment, 'bc')
       .innerJoin(User, 'u', 'bc.user_id = u.id')
       .where('bc.is_deleted = 0')
-      .andWhere('bc.comment_id = :id', { id: id })
+      .andWhere('bc.comment_id = :id', {id: id})
       .orderBy('bc.id', 'ASC')
       .getRawMany();
 
-      return comment;
+    return comment;
+  }
+
+  async getBlogComment(id: number): Promise<BlogComment> {
+    return await this.findOne(id);
   }
 }

--- a/src/api/feed/repository/blogComment.repository.ts
+++ b/src/api/feed/repository/blogComment.repository.ts
@@ -7,6 +7,10 @@ import { User } from 'src/entities/User';
 @Injectable()
 @EntityRepository(BlogComment)
 export class BlogCommentRepository extends Repository<BlogComment> {
+  createBlogComment(insBlogCommentDTO: InsBlogCommentDTO): BlogComment {
+    return this.create({...insBlogCommentDTO});
+  }
+  
   async saveBlogComment(
     queryRunner: QueryRunner | null,
     BlogComment: BlogComment,

--- a/src/entities/BlogComment.ts
+++ b/src/entities/BlogComment.ts
@@ -73,7 +73,7 @@ export class BlogComment {
   })
   regDate: Date;
 
-  @DeleteDateColumn({
+  @Column({
     name: 'del_date',
     type: 'timestamp',
     precision: 0,

--- a/src/shared/response_entities/feed/temp.response.ts
+++ b/src/shared/response_entities/feed/temp.response.ts
@@ -6,7 +6,7 @@ import {
 } from 'src/api/feed/dto/feed.dto';
 import {BaseResponse} from '../base.response';
 
-export abstract class FeedCreateResponseData {
+export abstract class FeedResponseData {
   @ApiProperty()
   status: true | false;
 }
@@ -17,7 +17,7 @@ export abstract class FeedCreateResponse extends BaseResponse {
   }
 
   @ApiProperty()
-  data: FeedCreateResponseData;
+  data: FeedResponseData;
 }
 
 export abstract class GetFeedViewResponse extends BaseResponse {
@@ -45,4 +45,13 @@ export abstract class GetListFeedLikeResponse extends BaseResponse {
 
   @ApiProperty({type: GetListFeedLikeResDTO})
   data: GetListFeedLikeResDTO;
+}
+
+export abstract class DeleteBlogCommentResponse extends BaseResponse {
+  constructor() {
+    super();
+  }
+
+  @ApiProperty()
+  data: FeedResponseData;
 }


### PR DESCRIPTION
- 일단 간단하게 request body에 댓글 id를 담아 전송하면 soft delete하는 방식으로 진행(인증관련처리x) 
- 기존 댓글엔티티에 DeleteDateColumn로 설정되어있던 is_deleted 컬럼을 기본 Column 데코레이터로 변경. 
soft delete를 위해 존재하는 데코레이터라 그런지 **데이터 조회시 where절에서 삭제 여부를 체크하는 조건을 자동으로 붙임**. 
=> 원댓글은 삭제됐지만 리댓글은 존재하는경우 리댓글까지 조회가 되지 않아 데코레이터 변경함.

그외에 큰 특이사항은 없습니다~
