### PR TITLE
피드 조회 관련 API 수정

### DIFF
--- a/src/api/feed/feed.controller.ts
+++ b/src/api/feed/feed.controller.ts
@@ -3,7 +3,6 @@ import {
   Get,
   Post,
   Body,
-  Patch,
   Param,
   Delete,
   UseInterceptors,
@@ -115,7 +114,6 @@ export class FeedController {
     @UploadedFiles() files: Express.Multer.File[],
     @Body() createFeedDTO: CreateFeedDTO,
   ) {
-    //return;
     const status = await this.feedService.create(files, createFeedDTO);
     const result: FeedCreateResponse = {
       code: status ? 201 : 500,

--- a/src/api/feed/feed.service.ts
+++ b/src/api/feed/feed.service.ts
@@ -231,6 +231,8 @@ export class FeedService {
         images: plainToInstance(GetBlogImageDTO, images),
       };
 
+      await this.blogPostRepository.updateBlogPostHits(id);
+
       return result;
     } catch (e) {
       this.logger.error(e);
@@ -325,13 +327,12 @@ export class FeedService {
     postId: number,
     promotions: string,
   ) {
-
     // 1. 모든 프로모션 삭제
     await this.blogPromotionRepository.deleteBlogPromotionByPostId(
       queryRunner,
       postId,
     );
-    
+
     // 2. 재저장
     await Promise.all(
       promotions.split(',').map(async id => {
@@ -406,7 +407,8 @@ export class FeedService {
 
     // 챌린지ID가 있다면, 챌린지ID에 맞는 데이터를 랜덤으로 노출
     let blogPostIds: number[] = [];
-    if (challengeId) {
+
+    if (+challengeId) {
       const blogChallenges =
         await this.blogChallengesRepository.getBlogChallengesByChallengeId(
           challengeId,
@@ -472,11 +474,13 @@ export class FeedService {
           blogImages.filter(bi => bi.postId === blogPost.id),
         );
       }),
-      isNext: isPageNext(
-        blogPosts.pagination.page,
-        blogPosts.pagination.take,
-        blogPosts.pagination.total,
-      ),
+      // SELECT절의 random()이 아니기 때문에, total과 상관없이 무한 스크롤 가능하게 수정
+      // isNext: isPageNext(
+      //   blogPosts.pagination.page,
+      //   blogPosts.pagination.take,
+      //   blogPosts.pagination.total,
+      // ),
+      isNext: true,
       total: blogPosts.pagination.total,
     };
   }

--- a/src/api/feed/interface/blogPost.interface.ts
+++ b/src/api/feed/interface/blogPost.interface.ts
@@ -1,6 +1,10 @@
 import {QueryRunner} from 'typeorm';
 import {BlogPost} from '../../../entities/BlogPost';
-import {CreateBlogPostDTO, GetBlogPostDTO, UpdateBlogPostDTO} from '../dto/feed.dto';
+import {
+  CreateBlogPostDTO,
+  GetBlogPostDTO,
+  UpdateBlogPostDTO,
+} from '../dto/feed.dto';
 
 export interface IBlogPostRepository {
   createBlogPost(
@@ -29,6 +33,7 @@ export interface IBlogPostRepository {
   ): Promise<IGetBlogPostItems>;
   getBlogPost(blogPostId: number): Promise<BlogPost>;
   getBlogPostById(id: number): Promise<GetBlogPostDTO>;
+  updateBlogPostHits(id: number): Promise<void>;
 }
 
 export interface IGetBlogPostItems {

--- a/src/api/feed/repository/blogComment.repository.ts
+++ b/src/api/feed/repository/blogComment.repository.ts
@@ -108,7 +108,7 @@ export class BlogCommentRepository extends Repository<BlogComment> {
       .select('blogComment.postId', 'postId')
       .addSelect('count(*)', 'commentCount')
       .where('blogComment.postId IN (:...postIds)', {
-        postIds,
+        postIds: postIds.length === 0 ? [] : postIds,
       })
       .groupBy('blogComment.postId')
       .getRawMany<IGetFeedsByCommentCountResponse>();


### PR DESCRIPTION
- 피드 게시글 목록 조회시 isNext는 항상 true로 설정
  - 랜덤 정렬로 인해 데이터를 보여주기 때문에, 영영 안보이는 데이터가 있을 수 있음
  - 피드 댓글 조회개수 SQL에서 피드가 없을 경우 에러 발생
- 피드 목록 조회 정렬기준 조회수와 등록일 내림차순으로 수정
  - 피드 상세 조회시 조회수 count 로직 추가