### PR TITLE
피드 삭제 API 구현

### DIFF
--- a/src/api/feed/dto/feed.dto.ts
+++ b/src/api/feed/dto/feed.dto.ts
@@ -16,7 +16,6 @@ export class CreateFeedDTO extends OmitType(BlogPost, [
   'modDate',
   'regDate',
   'delDate',
-  'isDeleted',
 ] as const) {
   @IsString()
   @IsNotEmpty()
@@ -43,7 +42,6 @@ export class UpdateFeedDTO extends OmitType(BlogPost, [
   'modDate',
   'regDate',
   'delDate',
-  'isDeleted',
 ] as const) {
   @ApiProperty({description: '게시글 id', example: '1'})
   id: number;
@@ -66,13 +64,14 @@ export class CreateBlogPostDTO extends OmitType(BlogPost, [
   'modDate',
   'regDate',
   'delDate',
-  'isDeleted',
 ] as const) {}
 
 export class CreateBlogChallengesDTO extends OmitType(BlogChallenges, ['id']) {}
 export class CreateBlogPromotionDTO extends OmitType(BlogPromotion, ['id']) {}
 export class CreateBlogImageDTO extends OmitType(BlogImage, ['id']) {}
-export class UpdateBlogPostDTO extends PartialType(OmitType(CreateBlogPostDTO, ['userId'])) {}
+export class UpdateBlogPostDTO extends PartialType(
+  OmitType(CreateBlogPostDTO, ['userId']),
+) {}
 
 export class GetListFeedMainReqDTO extends PagenationReqDTO {
   @ApiProperty({required: true, description: '챌린지ID', example: '1'})
@@ -532,4 +531,9 @@ export class GetListFeedLikeResDTO {
     example: GetFeedLikeDTO,
   })
   likes: GetFeedLikeDTO[];
+}
+
+export class DeleteFeedReqDTO {
+  @ApiProperty({description: '피드 id', example: '1'})
+  id: number;
 }

--- a/src/api/feed/feed.module.ts
+++ b/src/api/feed/feed.module.ts
@@ -11,6 +11,9 @@ import {BlogCommentRepository} from './repository/blogComment.repository';
 import {JwtOptionalGuard} from 'src/auth/jwt/jwtNoneRequired.guard';
 import {BlogLikeRepository} from 'src/api/like/repository/like.repository';
 import {UserRepository} from 'src/api/users/users.repository';
+import {UsersService} from 'src/api/users/users.service';
+import {FeedValidator} from 'src/api/feed/feed.validator';
+import {KakaoService} from 'src/auth/kakao.service';
 
 @Module({
   imports: [
@@ -26,6 +29,6 @@ import {UserRepository} from 'src/api/users/users.repository';
     ]),
   ],
   controllers: [FeedController],
-  providers: [FeedService, JwtOptionalGuard],
+  providers: [FeedService, JwtOptionalGuard, FeedValidator],
 })
 export class FeedModule {}

--- a/src/api/feed/feed.service.ts
+++ b/src/api/feed/feed.service.ts
@@ -24,6 +24,7 @@ import {
   GetBlogCommentDTO,
   DelBlogCommentReqDTO,
   UpdateBlogPostDTO,
+  DeleteFeedReqDTO,
 } from './dto/feed.dto';
 import {ImageService} from 'src/api/image/image.service';
 import {BlogChallengesRepository} from './repository/blogChallenges.repository';
@@ -530,7 +531,6 @@ export class FeedService {
 
       return result;
     } catch (e) {
-      this.logger.error(e);
       throw new HttpException(
         {
           error: e.message,
@@ -549,7 +549,27 @@ export class FeedService {
       comment.delDate = new Date();
       await this.blogCommentRepository.saveBlogComment(null, comment);
     } catch (e) {
-      throw new Error(e.message);
+      throw new HttpException(
+        {
+          error: e.message,
+          message: e.message,
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  async delete({id}: DeleteFeedReqDTO): Promise<void> {
+    try {
+      await this.blogPostRepository.deleteBlogPost(id);
+    } catch (error) {
+      throw new HttpException(
+        {
+          error: error.message,
+          message: error.message,
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 }

--- a/src/api/feed/feed.validator.ts
+++ b/src/api/feed/feed.validator.ts
@@ -1,0 +1,28 @@
+import {HttpException, HttpStatus, Injectable} from '@nestjs/common';
+import {InjectRepository} from '@nestjs/typeorm';
+import {IBlogPostRepository} from 'src/api/feed/interface/blogPost.interface';
+import {BlogPostRepository} from 'src/api/feed/repository/blogPost.repository';
+
+@Injectable()
+export class FeedValidator {
+  constructor(
+    @InjectRepository(BlogPostRepository)
+    private blogPostRepository: IBlogPostRepository,
+  ) {}
+
+  public async checkFeedAuthor(id: number, userId: number): Promise<void> {
+    const response = await this.blogPostRepository.selectBlogPostByUser(
+      id,
+      userId,
+    );
+
+    if (!response) {
+      throw new HttpException(
+        {
+          message: '게시글 삭제 권한이 없습니다',
+        },
+        HttpStatus.FORBIDDEN,
+      );
+    }
+  }
+}

--- a/src/api/feed/interface/blogPost.interface.ts
+++ b/src/api/feed/interface/blogPost.interface.ts
@@ -34,6 +34,11 @@ export interface IBlogPostRepository {
   getBlogPost(blogPostId: number): Promise<BlogPost>;
   getBlogPostById(id: number): Promise<GetBlogPostDTO>;
   updateBlogPostHits(id: number): Promise<void>;
+  deleteBlogPost(id: number, queryRunner?: QueryRunner): Promise<void>;
+  selectBlogPostByUser(
+    id: number,
+    userId: number,
+  ): Promise<BlogPost | undefined>;
 }
 
 export interface IGetBlogPostItems {

--- a/src/api/feed/repository/blogPost.repository.ts
+++ b/src/api/feed/repository/blogPost.repository.ts
@@ -147,4 +147,21 @@ export class BlogPostRepository
       .set({hits: () => '`hits` + 1'})
       .execute();
   }
+
+  async deleteBlogPost(id: number, queryRunner?: QueryRunner): Promise<void> {
+    await this.createQueryBuilder('blogPost', queryRunner)
+      .where('id = :id', {id})
+      .softDelete()
+      .execute();
+  }
+
+  async selectBlogPostByUser(
+    id: number,
+    userId: number,
+  ): Promise<BlogPost | undefined> {
+    return this.createQueryBuilder('blogPost')
+      .where('id = :id', {id})
+      .andWhere('blogPost.userId = :userId', {userId})
+      .getOne();
+  }
 }

--- a/src/api/users/users.service.ts
+++ b/src/api/users/users.service.ts
@@ -53,13 +53,13 @@ export class UsersService {
 
       await queryRunner.commitTransaction();
     } catch (error) {
+      await queryRunner.rollbackTransaction();
       throw new HttpException(
         {
           message: error.message,
         },
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
-      await queryRunner.rollbackTransaction();
     } finally {
       if (!queryRunner.isReleased) {
         await queryRunner.release();

--- a/src/entities/BlogPost.ts
+++ b/src/entities/BlogPost.ts
@@ -151,14 +151,6 @@ export class BlogPost {
   })
   delDate?: Date;
 
-  @Column({
-    name: 'is_deleted',
-    type: 'tinyint',
-    default: false,
-    comment: '삭제 여부',
-  })
-  isDeleted: boolean;
-
   @BeforeInsert()
   beforeInsert() {
     this.regDate = new Date();


### PR DESCRIPTION
- 게시글(blog_post) is_deleted 컬럼 제거
  - 삭제여부는 del_date 로 구분
- 피드 게시글 soft delete로 구현
  -  피드 게시글을 통과하지 않고, 피드와 관련된 데이터를 조회할 수 없음